### PR TITLE
implement multiprocessing of CVE retrieval and massively overhaul & enhance pastebin feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ usage: rhsecapi [--q-before YEAR-MM-DD] [--q-after YEAR-MM-DD] [--q-bug BZID]
                 [--q-cwe CWEID] [--q-cvss SCORE] [--q-cvss3 SCORE] [--q-empty]
                 [--q-pagesize PAGESZ] [--q-pagenum PAGENUM] [--q-raw RAWQUERY]
                 [--q-iava IAVA] [-x] [-f +FIELDS | -a | -m] [-j] [-u]
-                [-w [WIDTH]] [-c] [-v] [-t N] [-p] [-E [DAYS]] [-h] [--help]
+                [-w [WIDTH]] [-c] [-v] [-W N] [-p] [-E [DAYS]] [-h] [--help]
                 [CVE [CVE ...]]
 
 Run rhsecapi --help for full help page
@@ -453,7 +453,7 @@ usage: rhsecapi [--q-before YEAR-MM-DD] [--q-after YEAR-MM-DD] [--q-bug BZID]
                 [--q-cwe CWEID] [--q-cvss SCORE] [--q-cvss3 SCORE] [--q-empty]
                 [--q-pagesize PAGESZ] [--q-pagenum PAGENUM] [--q-raw RAWQUERY]
                 [--q-iava IAVA] [-x] [-f +FIELDS | -a | -m] [-j] [-u]
-                [-w [WIDTH]] [-c] [-v] [-t N] [-p] [-E [DAYS]] [-h] [--help]
+                [-w [WIDTH]] [-c] [-v] [-W N] [-p] [-E [DAYS]] [-h] [--help]
                 [CVE [CVE ...]]
 
 Make queries against the Red Hat Security Data API
@@ -529,8 +529,8 @@ GENERAL OPTIONS:
                         option is used but WIDTH is omitted
   -c, --count           Print a count of the number of entities found
   -v, --verbose         Print API urls to stderr
-  -t, --threads N       Set number of concurrent CVE queries to make (default
-                        on this system: 5)
+  -W, --workers N       Set number of concurrent worker processes to allow
+                        when making CVE queries (default on this system: 5)
   -p, --pastebin        Send output to Fedora Project Pastebin
                         (paste.fedoraproject.org) and print only URL to stdout
   -E, --pexpire [DAYS]  Set time in days after which paste will be deleted

--- a/README.md
+++ b/README.md
@@ -23,14 +23,13 @@ usage: rhsecapi [--q-before YEAR-MM-DD] [--q-after YEAR-MM-DD] [--q-bug BZID]
                 [--q-cwe CWEID] [--q-cvss SCORE] [--q-cvss3 SCORE] [--q-empty]
                 [--q-pagesize PAGESZ] [--q-pagenum PAGENUM] [--q-raw RAWQUERY]
                 [--q-iava IAVA] [-x] [-f +FIELDS | -a | -m] [-j] [-u]
-                [-w [WIDTH]] [-c] [-v] [-p] [-U NAME] [-E [DAYS]] [-h]
-                [--help]
+                [-w [WIDTH]] [-c] [-v] [-t N] [-p] [-E [DAYS]] [-h] [--help]
                 [CVE [CVE ...]]
 
 Run rhsecapi --help for full help page
 
 VERSION:
-  rhsecapi v0.2.1 last mod 2016/10/26
+  rhsecapi v0.6.11 last mod 2016/10/30
   See <http://github.com/ryran/redhat-security-data-api> to report bugs or RFEs
 ```
 
@@ -38,11 +37,14 @@ VERSION:
 
 ```
 $ rhsecapi CVE-2004-0230 CVE-2015-4642 CVE-2010-5298
+rhsecapi: 404 Client Error: Not Found for url: https://access.redhat.com/labs/securitydataapi/cve/CVE-2015-4642.json
+Valid Red Hat CVE results retrieved: 2 of 3
+Invalid CVE queries: 1 of 3
+
 CVE-2004-0230
   BUGZILLA:  No Bugzilla data
    Too new or too old? See: https://bugzilla.redhat.com/show_bug.cgi?id=CVE_legacy
 
-rhsecapi: 404 Client Error: Not Found for url: https://access.redhat.com/labs/securitydataapi/cve/CVE-2015-4642.json
 CVE-2015-4642
  Not present in Red Hat CVE database
  Try https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-4642
@@ -103,18 +105,20 @@ CVE-2010-5298 (https://access.redhat.com/security/cve/CVE-2010-5298)
 
 ```
 $ rhsecapi --
---all-fields      --most-fields     --q-before        --q-iava          --urls
---count           --pastebin        --q-bug           --q-package       --verbose
---extract-search  --p-expire        --q-cvss          --q-pagenum       --wrap
---fields          --p-user          --q-cvss3         --q-pagesize      
---help            --q-advisory      --q-cwe           --q-raw           
---json            --q-after         --q-empty         --q-severity      
+--all-fields      --most-fields     --q-bug           --q-package       --urls
+--count           --pastebin        --q-cvss          --q-pagenum       --verbose
+--extract-search  --pexpire         --q-cvss3         --q-pagesize      --wrap
+--fields          --q-advisory      --q-cwe           --q-raw
+--help            --q-after         --q-empty         --q-severity
+--json            --q-before        --q-iava          --threads
 ```
 
 ## Field display
 
 ```
 $ rhsecapi CVE-2016-5387 --fields cvss,cvss3
+Valid Red Hat CVE results retrieved: 1 of 1
+
 CVE-2016-5387
   CVSS:  5.0 (AV:N/AC:L/Au:N/C:N/I:P/A:N)
   CVSS3:  5.0 (CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:C/C:N/I:L/A:N)
@@ -122,6 +126,8 @@ CVE-2016-5387
 
 ```
 $ rhsecapi --fields +cvss,cwe CVE-2015-6525 --urls
+Valid Red Hat CVE results retrieved: 1 of 1
+
 CVE-2015-6525 (https://access.redhat.com/security/cve/CVE-2015-6525)
   IMPACT:  Moderate (https://access.redhat.com/security/updates/classification)
   DATE:  2015-08-24
@@ -151,6 +157,8 @@ CVE-2015-6525 (https://access.redhat.com/security/cve/CVE-2015-6525)
 
 ```
 $ rhsecapi CVE-2010-5298 -f +iava,cvss
+Valid Red Hat CVE results retrieved: 1 of 1
+
 CVE-2010-5298
   IMPACT:  Moderate
   DATE:  2014-04-08
@@ -176,6 +184,8 @@ CVE-2010-5298
 
 ```
 $ rhsecapi CVE-2016-5387 --all-fields
+Valid Red Hat CVE results retrieved: 1 of 1
+
 CVE-2016-5387
   IMPACT:  Important
   DATE:  2016-07-18
@@ -249,6 +259,8 @@ Getting 'https://access.redhat.com/labs/securitydataapi/cve.json?after=2014-12-0
 CVEs found: 1
 
 Getting 'https://access.redhat.com/labs/securitydataapi/cve/CVE-2015-0235.json' ...
+Valid Red Hat CVE results retrieved: 1 of 1
+
 CVE-2015-0235
   IMPACT:  Critical
   DATE:  2015-01-27
@@ -343,6 +355,10 @@ Invalid CVE queries: 1 of 4
 $ rhsecapi --q-iava 2016-A-0287 --extract-search 
 CVEs found: 4
 
+rhsecapi: 404 Client Error: Not Found for url: https://access.redhat.com/labs/securitydataapi/cve/CVE-2016-5604.json
+Valid Red Hat CVE results retrieved: 3 of 4
+Invalid CVE queries: 1 of 4
+
 CVE-2015-7940
   IMPACT:  Moderate
   DATE:  2015-09-14
@@ -394,7 +410,6 @@ CVE-2016-4979
    Not affected: Red Hat Enterprise Linux 6 [httpd]
    Not affected: Red Hat Enterprise Linux 7 [httpd]
 
-rhsecapi: 404 Client Error: Not Found for url: https://access.redhat.com/labs/securitydataapi/cve/CVE-2016-5604.json
 CVE-2016-5604
  Not present in Red Hat CVE database
  Try https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-5604
@@ -403,6 +418,10 @@ CVE-2016-5604
 ```
 $ rhsecapi --q-iava 2016-A-0287 -x -u -f affected_release
 CVEs found: 4
+
+rhsecapi: 404 Client Error: Not Found for url: https://access.redhat.com/labs/securitydataapi/cve/CVE-2016-5604.json
+Valid Red Hat CVE results retrieved: 3 of 4
+Invalid CVE queries: 1 of 4
 
 CVE-2015-7940 (https://access.redhat.com/security/cve/CVE-2015-7940)
   AFFECTED_RELEASE (ERRATA):
@@ -420,7 +439,6 @@ CVE-2016-4979 (https://access.redhat.com/security/cve/CVE-2016-4979)
    Red Hat Software Collections for Red Hat Enterprise Linux Server (v. 6) [httpd24-httpd-2.4.18-11.el6]: https://access.redhat.com/errata/RHSA-2016:1420
    Red Hat Software Collections for Red Hat Enterprise Linux Server (v. 7) [httpd24-httpd-2.4.18-11.el7]: https://access.redhat.com/errata/RHSA-2016:1420
 
-rhsecapi: 404 Client Error: Not Found for url: https://access.redhat.com/labs/securitydataapi/cve/CVE-2016-5604.json
 CVE-2016-5604
  Not present in Red Hat CVE database
  Try https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-5604
@@ -435,8 +453,7 @@ usage: rhsecapi [--q-before YEAR-MM-DD] [--q-after YEAR-MM-DD] [--q-bug BZID]
                 [--q-cwe CWEID] [--q-cvss SCORE] [--q-cvss3 SCORE] [--q-empty]
                 [--q-pagesize PAGESZ] [--q-pagenum PAGENUM] [--q-raw RAWQUERY]
                 [--q-iava IAVA] [-x] [-f +FIELDS | -a | -m] [-j] [-u]
-                [-w [WIDTH]] [-c] [-v] [-p] [-U NAME] [-E [DAYS]] [-h]
-                [--help]
+                [-w [WIDTH]] [-c] [-v] [-t N] [-p] [-E [DAYS]] [-h] [--help]
                 [CVE [CVE ...]]
 
 Make queries against the Red Hat Security Data API
@@ -512,11 +529,11 @@ GENERAL OPTIONS:
                         option is used but WIDTH is omitted
   -c, --count           Print a count of the number of entities found
   -v, --verbose         Print API urls to stderr
+  -t, --threads N       Set number of concurrent CVE queries to make (default
+                        on this system: 5)
   -p, --pastebin        Send output to Fedora Project Pastebin
                         (paste.fedoraproject.org) and print only URL to stdout
-  -U, --p-user NAME     Set alphanumeric paste author (default: 'rhsecapi')
-  -E, --p-expire [DAYS]
-                        Set time in days after which paste will be deleted
+  -E, --pexpire [DAYS]  Set time in days after which paste will be deleted
                         (defaults to '28'; specify '0' to disable expiration;
                         DAYS defaults to '2' if option is used but DAYS is
                         omitted)
@@ -524,7 +541,7 @@ GENERAL OPTIONS:
   --help                Show this help message and exit
 
 VERSION:
-  rhsecapi v0.2.1 last mod 2016/10/26
+  rhsecapi v0.6.11 last mod 2016/10/30
   See <http://github.com/ryran/redhat-security-data-api> to report bugs or RFEs
 ```
 

--- a/rhsecapi.py
+++ b/rhsecapi.py
@@ -41,7 +41,7 @@ prog = 'rhsecapi'
 vers = {}
 vers['version'] = '0.6.11'
 vers['date'] = '2016/10/30'
-# Set default number of threads to use
+# Set default number of workers to use
 cpuCount = multiprocessing.cpu_count() + 1
 # Supported CVE fields
 allFields = ['threat_severity',
@@ -364,8 +364,8 @@ def parse_args():
         '-v', '--verbose', action='store_true',
         help="Print API urls to stderr")
     g_general.add_argument(
-        '-t', '--threads', metavar='N', type=int, default=cpuCount,
-        help="Set number of concurrent CVE queries to make (default on this system: {0})".format(cpuCount))
+        '-W', '--workers', metavar='N', type=int, default=cpuCount,
+        help="Set number of concurrent worker processes to allow when making CVE queries (default on this system: {0})".format(cpuCount))
     g_general.add_argument(
         '-p', '--pastebin', action='store_true',
         help="Send output to Fedora Project Pastebin (paste.fedoraproject.org) and print only URL to stdout")
@@ -777,7 +777,7 @@ def main(opts):
         # Disable sigint before starting process pool
         import signal
         original_sigint_handler = signal.signal(signal.SIGINT, signal.SIG_IGN)
-        pool = multiprocessing.Pool(opts.threads)
+        pool = multiprocessing.Pool(opts.workers)
         # Re-enable receipt of sigint
         signal.signal(signal.SIGINT, original_sigint_handler)
         try:

--- a/rhsecapi.py
+++ b/rhsecapi.py
@@ -39,7 +39,7 @@ except:
 # Globals
 prog = 'rhsecapi'
 vers = {}
-vers['version'] = '0.6.10'
+vers['version'] = '0.6.11'
 vers['date'] = '2016/10/30'
 # Set default number of threads to use
 cpuCount = multiprocessing.cpu_count() + 1
@@ -383,7 +383,7 @@ def parse_args():
     #     '--p-public', dest='p_private', default='yes', action='store_const', const='no',
     #     help="Set paste to be publicly-discoverable")
     g_general.add_argument(
-        '-E', '--p-expire', metavar='DAYS', nargs='?', const=2, default=28, type=int,
+        '-E', '--pexpire', metavar='DAYS', nargs='?', const=2, default=28, type=int,
         help="Set time in days after which paste will be deleted (defaults to '28'; specify '0' to disable expiration; DAYS defaults to '2' if option is used but DAYS is omitted)")
     # g_general.add_argument(
     #     '--p-project', metavar='PROJECT',
@@ -754,7 +754,6 @@ def main(opts):
             else:
                 for cve in result:
                     searchOutput.append(cve['CVE'] + "\n")
-            searchOutput.append("\n")
             if not opts.pastebin:
                 print("".join(searchOutput))
     elif opts.q_iava:
@@ -768,10 +767,13 @@ def main(opts):
             else:
                 for cve in result['IAVM']['CVEs']['CVENumber']:
                     iavaOutput.append(cve + "\n")
-            iavaOutput.append("\n")
             if not opts.pastebin:
                 print("".join(iavaOutput))
     if opts.cves:
+        if searchOutput:
+            searchOutput.append("\n")
+        if iavaOutput:
+            iavaOutput.append("\n")
         pool = multiprocessing.Pool(opts.threads)
         results = pool.map(a.print_cve, opts.cves)
         pool.close()
@@ -791,7 +793,7 @@ def main(opts):
             opts.p_lang = 'Python'
         data = "".join(searchOutput) + "".join(iavaOutput) + "".join(cveOutput)
         try:
-            response = fpaste_it(inputdata=data, author=prog, lang=opts.p_lang, expire=opts.p_expire)
+            response = fpaste_it(inputdata=data, author=prog, lang=opts.p_lang, expire=opts.pexpire)
         except ValueError as e:
             print(e, file=stderr)
             print("{0}: Submitting to pastebin failed; print results to stdout instead? [y]".format(prog), file=stderr)
@@ -800,7 +802,7 @@ def main(opts):
                 print(data, end="")
         else:
             print(response)
-    else:
+    elif opts.cves:
         print("".join(cveOutput), end="")
     
 


### PR DESCRIPTION
#15 #14 

Search queries (`--q-xxx`) are always done by a single API (or IAVM Mapper app) request.

However, each CVE retrieval was a separate http request against the API and when querying dozens or hundreds of CVEs in serial, the time starts really adding up.

**These commits implement multiprocessing for CVE retrieval.**

By default, there will be `NUM_CPUS + 1` separate worker processes used for making requests. Configurable via `-W` or `--workers`, e.g., on my 4-core system, the help page printed:

```
  -W, --workers N       Set number of concurrent worker processes to allow
                        when making CVE queries (default on this system: 5)
```

With these commits, the pastebin system is also massively more robust and handles lots of errors. Woo hoo! Especially important: it gracefully exits (& explains) when trying to send too much data to pastebin (i.e., `>= 512 KiB`). When there are exceptions with the pastebin stuff, approporiate messages are now printed but rhsecapi also actually offers to print the gathered data (that would have been posted to pastebin) to stdout instead.

Last but not least, Ctrl-c still works, even when in the middle the multi-process CVE retrieval.