### PR TITLE
Fix Log bug #67

### DIFF
--- a/rhsda.py
+++ b/rhsda.py
@@ -632,7 +632,7 @@ class ApiClient:
         for f in fields:
             # Skip unknown fields
             if f not in cveFields.all_plus_aliases:
-                logger.warning("Field '{0}' is not a known field; valid fields:\n{2}".format(f, ", ".join(cveFields.all_plus_aliases)))
+                logger.warning("Field '{0}' is not a known field; valid fields:\n{1}".format(f, ", ".join(cveFields.all_plus_aliases)))
                 continue
             # Look-up aliases
             if f not in cveFields.all:

--- a/rhsda.py
+++ b/rhsda.py
@@ -31,13 +31,7 @@ from argparse import Namespace
 
 
 # Logging
-logging.addLevelName(25, 'NOTICE')
-consolehandler = logging.StreamHandler()
-consolehandler.setLevel('DEBUG')
-consolehandler.setFormatter(logging.Formatter("[%(levelname)-7s] %(name)s: %(message)s"))
-logger = logging.getLogger('rhsda')
-logger.setLevel('NOTICE')
-logger.addHandler(consolehandler)
+logger = logging.getLogger(__name__)
 
 
 # Establish cveFields namespace
@@ -176,7 +170,6 @@ class ApiClient:
     def __init__(self, logLevel='notice'):
         self.cfg = Namespace()
         self.cfg.apiUrl = 'https://access.redhat.com/labs/securitydataapi'
-        logger.setLevel(logLevel.upper())
 
     def _get_terminal_width(self):
         h, w, hp, wp = struct.unpack('HHHH', fcntl.ioctl(0, termios.TIOCGWINSZ, struct.pack('HHHH', 0, 0, 0, 0)))

--- a/rhsecapi.py
+++ b/rhsecapi.py
@@ -48,15 +48,21 @@ prog = 'rhsecapi'
 vers = {}
 vers['version'] = '1.0.1'
 vers['date'] = '2017/06/27'
+logLevels = {
+    'DEBUG': logging.DEBUG,
+    'INFO': logging.INFO,
+    'WARNING': logging.WARNING,
+    'NOTICE': 25,
+    'ERROR': logging.ERROR,
+}
+
 
 
 # Logging
-logging.addLevelName(25, 'NOTICE')
+logging.addLevelName(logLevels['NOTICE'], 'NOTICE')
 consolehandler = logging.StreamHandler()
-consolehandler.setLevel('DEBUG')
 consolehandler.setFormatter(logging.Formatter("[%(levelname)-7s] %(name)s: %(message)s"))
-logger = logging.getLogger('rhsecapi')
-logger.setLevel('NOTICE')
+logger = logging.getLogger()
 logger.addHandler(consolehandler)
 
 
@@ -340,7 +346,7 @@ def parse_args():
         o.outFormat = 'jsonpretty'
     else:
         o.outFormat = 'plaintext'
-    logger.setLevel(o.loglevel.upper())
+    logger.setLevel(logLevels[o.loglevel.upper()])
     return o
 
 


### PR DESCRIPTION
Fix logging to work with python 2.6

o setLevel silently ignores non integers, so strings cannot be used.
o getLogger at the top level needs to be 'root' if submodules are to
    inherit correctly.

Tidied up the library logging definition to inherit from the root logger.

Addresses Issue: #67
