### PR TITLE
Add docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM centos:7
+
+RUN yum --nogpgcheck -y install http://people.redhat.com/rsawhill/rpms/latest-rsawaroha-release.rpm
+
+RUN yum --nogpgcheck -y install rhsecapi

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ sys	0m0.055s
   1. Optional: `mkdir -p ~/bin; ln -sv /PATH/TO/rhsecapi.py ~/bin/rhsecapi`
   1. Execute: `rhsecapi`
 
-- **Option 3: Install docker version
+- **Option 3: Install docker version**
   1. cd rhsecpai
   1. yum install docker for RHEL, can depend on your OS
   1. chmod +x install_docker.sh

--- a/README.md
+++ b/README.md
@@ -179,6 +179,12 @@ sys	0m0.055s
   1. Optional: `mkdir -p ~/bin; ln -sv /PATH/TO/rhsecapi.py ~/bin/rhsecapi`
   1. Execute: `rhsecapi`
 
+- **Option 3: Install docker version
+  1. cd rhsecpai
+  1. yum install docker for RHEL, can depend on your OS
+  1. chmod +x install_docker.sh
+  1. sudo ./install_docker.sh
+  1. rhsecapi.sh CVE-2015-4642
   
 ## Abbreviated usage
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+
+services:
+  centos_rhsecapi:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: centos_rhsecapi
+    restart: always
+    command: bash
+    tty: true

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+if ! command -v docker &> /dev/null; then
+    echo "Docker is not installed. Please install Docker and try again."
+    exit 1
+fi
+
+if ! docker info &> /dev/null; then
+    echo "Docker is not running. Please start Docker and try again."
+    exit 1
+fi
+
+docker-compose build
+docker-compose up -d
+
+cat <<EOF > /usr/bin/rhsecapi.sh
+#!/bin/bash
+
+# Wrapper script to run rhsecapi inside the Docker container
+
+DOCKER_CONTAINER_NAME="centos_rhsecapi"
+
+docker exec -it \$DOCKER_CONTAINER_NAME rhsecapi "\$@"
+EOF
+
+chmod +x /usr/bin/rhsecapi.sh
+
+echo "Script executed successfully."

--- a/install_docker.sh
+++ b/install_docker.sh
@@ -25,4 +25,4 @@ EOF
 
 chmod +x /usr/bin/rhsecapi.sh
 
-echo "Script executed successfully."
+echo "rhsecapi docker installed!."


### PR DESCRIPTION
As I've seen from many users here, current support for RHEL8 or any other OS is deprecated due to the Python 2 issue. So, I've created a Docker version of it that should fix the dependency issues for any user who wants to run this on RHEL7, RHEL8, RHEL9, or any other OS.

The install_docker.sh script does the build and runs the container, also creating a script in /usr/bin

For example, you can run `rhsecapi.sh CVE-2013-4113 CVE-2014-3669 CVE-2004-0230 CVE-2015-4642`, and the result will be as executing the script in the main OS:

result:

```
Missing optional python module: argcomplete

  To enable bash auto-magic tab-completion, install it:
    yum/dnf install python-pip
    pip install argcomplete
    activate-global-python-argcomplete
    (Open new shell)

  To skip using argcomplete AND disable future printing of this message:
    touch ~/.rhsecapi-no-argcomplete
      OR
    touch /etc/rhsecapi-no-argcomplete

[NOTICE ] rhsda: Found 4 CVEs on cmdline
[NOTICE ] rhsda: Valid Red Hat CVE results retrieved: 3 of 4

CVE-2013-4113
  SEVERITY : Critical Impact
  DATE     : 2013-07-11
  BUGZILLA : 983689
  FIXED_RELEASES :
   Red Hat Enterprise Linux 3 Extended Lifecycle Support: [php-0:4.3.2-56.ent] via RHSA-2013:1063 (2013-07-15)
   Red Hat Enterprise Linux 4 Extended Lifecycle Support: [php-0:4.3.9-3.37.el4] via RHSA-2013:1063 (2013-07-15)
   Red Hat Enterprise Linux 5: [php-0:5.1.6-40.el5_9] via RHSA-2013:1049 (2013-07-12)
   Red Hat Enterprise Linux 5: [php53-0:5.3.3-13.el5_9.1] via RHSA-2013:1050 (2013-07-12)
   Red Hat Enterprise Linux 5.3 Long Life: [php-0:5.1.6-23.4.el5_3] via RHSA-2013:1061 (2013-07-15)
   Red Hat Enterprise Linux 5.6 EUS - Server Only: [php-0:5.1.6-27.el5_6.5] via RHSA-2013:1061 (2013-07-15)
   Red Hat Enterprise Linux 5.6 EUS - Server Only: [php53-0:5.3.3-1.el5_6.3] via RHSA-2013:1062 (2013-07-15)
   Red Hat Enterprise Linux 6: [php-0:5.3.3-23.el6_4] via RHSA-2013:1049 (2013-07-12)
   Red Hat Enterprise Linux 6.2 EUS - Server and Compute Node Only: [php-0:5.3.3-3.el6_2.10] via RHSA-2013:1061 (2013-07-15)
   Red Hat Enterprise Linux 6.3 EUS - Server and Compute Node Only: [php-0:5.3.3-14.el6_3.1] via RHSA-2013:1061 (2013-07-15)
  FIX_STATES :
   Not affected: Red Hat Enterprise Linux 7 [php]
   Not affected: Red Hat Software Collections [php54-php]

CVE-2014-3669
  SEVERITY : Moderate Impact
  DATE     : 2014-09-18
  BUGZILLA : 1154500
  FIXED_RELEASES :
   Red Hat Enterprise Linux 5: [php53-0:5.3.3-26.el5_11] via RHSA-2014:1768 (2014-10-30)
   Red Hat Enterprise Linux 5: [php-0:5.1.6-45.el5_11] via RHSA-2014:1824 (2014-11-06)
   Red Hat Enterprise Linux 6: [php-0:5.3.3-40.el6_6] via RHSA-2014:1767 (2014-10-30)
   Red Hat Enterprise Linux 6.5 Extended Update Support: [php-0:5.3.3-27.el6_5.3] via RHSA-2015:0021 (2015-01-08)
   Red Hat Enterprise Linux 7: [php-0:5.4.16-23.el7_0.3] via RHSA-2014:1767 (2014-10-30)
   Red Hat Software Collections 1 for Red Hat Enterprise Linux 6: [php54-php-0:5.4.16-22.el6] via RHSA-2014:1765 (2014-10-30)
   Red Hat Software Collections 1 for Red Hat Enterprise Linux 6: [php55-php-0:5.5.6-13.el6] via RHSA-2014:1766 (2014-10-30)
   Red Hat Software Collections 1 for Red Hat Enterprise Linux 6.4 EUS: [php54-php-0:5.4.16-22.el6] via RHSA-2014:1765 (2014-10-30)
   Red Hat Software Collections 1 for Red Hat Enterprise Linux 6.4 EUS: [php55-php-0:5.5.6-13.el6] via RHSA-2014:1766 (2014-10-30)
   Red Hat Software Collections 1 for Red Hat Enterprise Linux 6.5 EUS: [php54-php-0:5.4.16-22.el6] via RHSA-2014:1765 (2014-10-30)
   Red Hat Software Collections 1 for Red Hat Enterprise Linux 6.5 EUS: [php55-php-0:5.5.6-13.el6] via RHSA-2014:1766 (2014-10-30)
   Red Hat Software Collections 1 for Red Hat Enterprise Linux 6.6 EUS: [php54-php-0:5.4.16-22.el6] via RHSA-2014:1765 (2014-10-30)
   Red Hat Software Collections 1 for Red Hat Enterprise Linux 6.6 EUS: [php55-php-0:5.5.6-13.el6] via RHSA-2014:1766 (2014-10-30)
   Red Hat Software Collections 1 for Red Hat Enterprise Linux 7: [php54-php-0:5.4.16-22.el7] via RHSA-2014:1765 (2014-10-30)
   Red Hat Software Collections 1 for Red Hat Enterprise Linux 7: [php55-php-0:5.5.6-13.el7] via RHSA-2014:1766 (2014-10-30)

CVE-2004-0230
  BUGZILLA : No Bugzilla data
   Too new or too old? See: https://bugzilla.redhat.com/show_bug.cgi?id=CVE_legacy

CVE-2015-4642
  Not present in Red Hat CVE database
  Try https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-4642
```

it creates a wrapper for the docker in /usr/bin/rhsecapi.sh that you can use with commands